### PR TITLE
Replace usage of eval and exec

### DIFF
--- a/pycromanager/core.py
+++ b/pycromanager/core.py
@@ -232,11 +232,9 @@ class JavaObjectShadow:
         for method_name in method_names:
             params, methods_with_name, method_name_modified = _parse_arg_names(methods, method_name, self._convert_camel_case)
             return_type = methods_with_name[0]['return-type']
-            #use exec so the arguments can have default names that indicate type hints
-            argNames = [param.name for param in params]
             fn = lambda instance, *args, signatures_list=methods_with_name: instance._translate_call(signatures_list, *args)
             fn.__name__ = method_name_modified
-            fn.__doc__ = "{}: A dynamically generated Java method.".format(method_name_modified)
+            fn.__doc__ = "{}.{}: A dynamically generated Java method.".format(self._java_class, method_name_modified)
             sig = inspect.signature(fn)
             params = [inspect.Parameter('self', inspect.Parameter.POSITIONAL_ONLY)]+params # Add `self` as the first argument.
             return_type = _JAVA_TYPE_NAME_TO_PYTHON_TYPE[return_type] if return_type in _JAVA_TYPE_NAME_TO_PYTHON_TYPE else return_type
@@ -411,7 +409,6 @@ def _check_method_args(method_specs, fn_args):
 
 
 def _parse_arg_names(methods, method_name, convert_camel_case):
-    # dont delete because this is used in the exec
     method_name_modified = _camel_case_2_snake_case(method_name) if convert_camel_case else method_name
     # all methods with this name and different argument lists
     methods_with_name = [m for m in methods if m['name'] == method_name]

--- a/pycromanager/core.py
+++ b/pycromanager/core.py
@@ -436,8 +436,6 @@ def _parse_arg_names(methods, method_name, convert_camel_case):
         else:
             default_arg_value = inspect.Parameter.empty
         params.append(inspect.Parameter(name=arg_name, kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, default=default_arg_value, annotation=python_type))
-    if method_name_modified == 'set_roi':
-        a = 1
     return params, methods_with_name, method_name_modified
 
 

--- a/pycromanager/core.py
+++ b/pycromanager/core.py
@@ -1,14 +1,13 @@
 import json
 import re
 import time
-import typing
 import warnings
 from base64 import standard_b64encode, standard_b64decode
 import inspect
 
 import numpy as np
 import zmq
-from types import MethodType, FunctionType
+from types import MethodType
 
 
 class JavaSocket:


### PR DESCRIPTION
This PR replaces the usage of eval and exec for dynamic generation of methods to mirror java methods.

The reasoning for this is the `exec` and `eval` can cause a number of problems:
 - IDE's don't recognize the code in exec statements so automatic refactoring can easily break them.
 - Complex string formatting for the purpose of code generation is very difficult to read.
 - Any code executed within an exec statement cannot be reached by a debugger.

Additional changes:
 - `_parse_arg_names` no longer needlessly loops though all items of `methods_with_name` when only the last one is actually used.
 - Generated methods now have type annotations for arguments and return values
 - Generated methods now have generated docstrings.

For example here is the output from the built-in `help` function
`help(Bridge.get_studio().set_roi)`
```
set_roi(object: 'java.awt.Rectangle') -> None method of pycromanager.JavaObjectShadow instance
    org.micromanager.internal.MMStudio.set_roi: A dynamically generated Java method.
```

whereas previously it would have been.

```
<lambda> lambda object method of pycromanager.JavaObjectShadow instance
```