### PR TITLE
correct homepage url on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description="Open source microscope control using python",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/henrypinkard/pycro-manager",
+    url="https://github.com/micro-manager/pycro-manager",
     packages=setuptools.find_packages(),
     install_requires=['numpy', 'dask[array]>=2.4.0', 'zmq'],
     python_requires='>=3.6',


### PR DESCRIPTION
The current homepage link on pypi links to what looks like the original repo before this joined the micro-manager org. This makes the canonical repo easier to find.

p.s. This is fantastic thank you so much