### PR TITLE
add check for if tile_height and tile_width have been defined

### DIFF
--- a/pycromanager/data.py
+++ b/pycromanager/data.py
@@ -590,7 +590,7 @@ class Dataset:
                 if (self._tile_height is not None) and (self._tile_width is not None):
                     #crop down to just the part that shows (i.e. no overlap)
                     image = image[(image.shape[0] - self._tile_height) // 2: -(image.shape[0] - self._tile_height) // 2,
-                                (image.shape[0] - self._tile_width) // 2: -(image.shape[0] - self._tile_width) // 2]
+                                (image.shape[1] - self._tile_width) // 2: -(image.shape[1] - self._tile_width) // 2]
             else:
                 image = np.reshape(tagged_image.pix, newshape=[self._tile_height, self._tile_width])
             if read_metadata:

--- a/pycromanager/data.py
+++ b/pycromanager/data.py
@@ -271,6 +271,8 @@ class Dataset:
 
 
     def __init__(self, dataset_path=None, full_res_only=True, remote_storage=None):
+        self._tile_width = None
+        self._tile_height = None
         if remote_storage is not None:
             #this dataset is a view of an active acquisiiton. The storage exists on the java side
             self._remote_storage = remote_storage
@@ -585,9 +587,10 @@ class Dataset:
             if resolution_level == 0:
                 image = np.reshape(tagged_image.pix,
                                     newshape=[tagged_image.tags['Height'], tagged_image.tags['Width']])
-                #crop down to just the part that shows (i.e. no overlap)
-                image = image[(image.shape[0] - self._tile_height) // 2: -(image.shape[0] - self._tile_height) // 2,
-                            (image.shape[0] - self._tile_width) // 2: -(image.shape[0] - self._tile_width) // 2]
+                if (self._tile_height is not None) and (self._tile_width is not None):
+                    #crop down to just the part that shows (i.e. no overlap)
+                    image = image[(image.shape[0] - self._tile_height) // 2: -(image.shape[0] - self._tile_height) // 2,
+                                (image.shape[0] - self._tile_width) // 2: -(image.shape[0] - self._tile_width) // 2]
             else:
                 image = np.reshape(tagged_image.pix, newshape=[self._tile_height, self._tile_width])
             if read_metadata:


### PR DESCRIPTION
`_tile_height` and `_tile_width` in `Dataset` are not garunteed to be defined, but they were still being used to reshape images which was leading to errors. Heres an example of how to reproduce the errors:

```python
from pycromanager import Bridge
from pycromanager import Acquisition, multi_d_acquisition_events

bridge = Bridge()
core = bridge.get_core()
mmStudio = bridge.get_studio()

z_pos = core.get_position()
z_delta = 3
z_start = z_pos - z_delta
z_end = z_pos + z_delta
z_step = 1
events = multi_d_acquisition_events(1,z_start= z_start, z_end = z_end,z_step=z_step, channel_group = 'UPLSAPO40X',channels=['BF', 'GFP'])
events = multi_d_acquisition_events(1,z_start= z_start, z_end = z_end,z_step=z_step,
                                    channel_group = 'UPLSAPO40X',channels=['BF', 'GFP'])
with Acquisition(directory='test', name='acq-test',post_hardware_hook_fn=f) as acq:
    acq.acquire(events)
dataset = acq.get_dataset()
dataset.read_image(z=5)
```

which leads to this error (slightly autoformatted by my editor bc I was derping around in the file):
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-12-6876a9f4c299> in <module>
----> 1 dataset.read_image(z=5)

~\miniconda3\envs\control\lib\site-packages\pycromanager\data.py in read_image(self, channel, z, time, position, channel_name, read_metadata, resolution_level, row, col, memmapped, **kwargs)
    813                 # if (self._tile_height is not None) and (self._tile_width is not None):
    814                 image = image[
--> 815                     (image.shape[0] - self._tile_height)
    816                     // 2 : -(image.shape[0] - self._tile_height)
    817                     // 2,

AttributeError: 'Dataset' object has no attribute '_tile_height'
```

I also changed the indexing of the shape because the height was being used for both width and height. (If this was wrong I'll rebase and drop the commit)