### PR TITLE
add two jupyter notebooks related with light sheet imaging

### DIFF
--- a/docs/source/Stage-scanned light sheet imaging.ipynb
+++ b/docs/source/Stage-scanned light sheet imaging.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stage-scanned light sheet imaging \n",
+    "\n",
+    "This notebook explains how to perform stage-scanned light sheet imaging. \n",
+    "\n",
+    "To acquire a z-stack, the camera is set to 'External Start' mode. The stage moves at a constant speed\n",
+    "during the acqusition. When the stage initiates the scanning, it sends out a TTL to trigger the camera\n",
+    "to start acquisiton.\n",
+    "\n",
+    "To acquire a time lapse 3D dataset, the process described above is repeated for n times \n",
+    "(n: number of time points).\n",
+    "\n",
+    "Note: \n",
+    "To avoid motion blur during the stage scan, a method called 'Light-sheet stablized stage scanning \n",
+    "(LS3)' is used. With this method, A galo mirror is used to offset the stage motion during each frame.\n",
+    "The galvo is controlled independently by another python script using the NI-DAQmax API.\n",
+    "Details of the LS3 methods can be found in: \n",
+    "https://www.biorxiv.org/content/10.1101/2020.09.22.309229v1 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pycromanager import Bridge, Acquisition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define a hook function to start the scanning of the stage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def move_stage(event):\n",
+    "    message = \"scan\"\n",
+    "    core.set_serial_port_command(port, message, \"\\r\")\n",
+    "    return event"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Construct java objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bridge = Bridge()\n",
+    "core = bridge.get_core()\n",
+    "mm = bridge.get_studio()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Acquisition parameter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nb_timepoints = 5\n",
+    "scan_step = 2.0           # unit: um\n",
+    "stage_scan_range = 200.0  # unit: um\n",
+    "interval = 1              # interval time between each time point, unit: second\n",
+    "exposureMs = core.get_exposure()\n",
+    "nrSlices = int(stage_scan_range / scan_step)\n",
+    "\n",
+    "save_directory = r'E:\\data'\n",
+    "save_name = 'test'\n",
+    "    \n",
+    "port = \"COM4\"\n",
+    "speed = scan_step / exposureMs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stage settings\n",
+    "Note: an ASI MS200 stage is used here. If you have a different stage, consult the manual to find out \n",
+    "the correct way to operate it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "set backlash: backlash x=0.02 y=0.0\n",
+      "set speed to scan:  speed x=0.0999\n",
+      "scan range: scanr x=0.0 y=0.2000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set backlash\n",
+    "message = \"backlash x=0.02 y=0.0\"\n",
+    "print(\"set backlash: \" + message)\n",
+    "core.set_serial_port_command(port, message, \"\\r\")\n",
+    "\n",
+    "# set default speed\n",
+    "message = \"speed x=10 y=10\"\n",
+    "core.set_serial_port_command(port, message, \"\\r\")\n",
+    "\n",
+    "# set speed. note: here x-axis is the stage motion axis.\n",
+    "message = \"speed x=\" + \"{:.4f}\".format(speed)\n",
+    "print(\"set speed to scan: \", message)\n",
+    "core.set_serial_port_command(port, message, \"\\r\")\n",
+    "\n",
+    "# set current position to zero\n",
+    "message = \"zero\"\n",
+    "core.set_serial_port_command(port, message, \"\\r\")\n",
+    "\n",
+    "# set the scan range\n",
+    "message = \"scanr x=0.0 y=\" + \"{:.4f}\".format(stage_scan_range / 1000)\n",
+    "print(\"scan range: \" + message)\n",
+    "core.set_serial_port_command(port, message, \"\\r\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Camera settings\n",
+    "Note: an Hamamasty Flash 4.0 camear is used here. If you have a different camera, consult the manual \n",
+    "to find out the correct way to set the parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Camera trigger settings\n",
+    "core.set_property(\"HamamatsuHam_DCAM\", \"TRIGGER SOURCE\", \"EXTERNAL\")\n",
+    "core.set_property(\"HamamatsuHam_DCAM\", \"TRIGGER DELAY\", \"0.0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The main function to perform the time lampse 3D imaging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == '__main__':\n",
+    "    # generate the multi-dimensional events \n",
+    "    events = []\n",
+    "    for t in range(nb_timepoints):\n",
+    "        event = []\n",
+    "        for z in range(nrSlices):\n",
+    "            event.append({'axes': {'time': t, 'z': z}, 'min_start_time': interval})\n",
+    "        events.append(event)\n",
+    "    print(events)\n",
+    "\n",
+    "    with Acquisition(directory=save_directory,\n",
+    "                     name=save_name,\n",
+    "                     pre_hardware_hook_fn=sleep,\n",
+    "                     post_camera_hook_fn=move_stage) as acq:\n",
+    "        for t in range(nb_timepoints):\n",
+    "            acq.acquire(events[t])\n",
+    "        acq.await_completion()\n",
+    "\n",
+    "    # set back camera property\n",
+    "    core.set_property(\"HamamatsuHam_DCAM\", \"TRIGGER SOURCE\", \"INTERNAL\")\n",
+    "\n",
+    "    # set the stage to default speed\n",
+    "    message = \"speed x=10 y=10\"\n",
+    "    core.set_serial_port_command(port, message, \"\\r\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/convert MM MDA data into zarr.ipynb
+++ b/docs/source/convert MM MDA data into zarr.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Convert Micromanager multidimensional tiff data into zarr format  \n",
+    "\n",
+    "This notebook explains how to use Pycromanger to readout the multi-dimensional data saved by Micro-manager and convert it into zarr format. \n",
+    "\n",
+    "This is useful when the multi-dimensional data is large (more than hundreds of GBs). Currently there is no python reader that can directly readout the large multi-dimensional data saved by Micromanger. Therefore, Pycromanger can be used as a reader to bridge this gap.\n",
+    "\n",
+    "To run this notebook, first open Micromanger, then load the multi-dimensional data into Micromanger using virtual stack. Pycromanger will then be able to read out that data via a Java-Python bridge.\n",
+    "\n",
+    "After the data is converted to zarr, one can easier load the data into Python and perform downsteam processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import zarr\n",
+    "import numpy as np\n",
+    "from pycromanager import Bridge"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Construct java objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bridge = Bridge()\n",
+    "mm = bridge.get_studio()\n",
+    "ds = mm.displays().get_active_data_viewer().get_data_provider()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set parameters\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nb_tp = 500  # number of time points\n",
+    "nb_ch = 2    # number of channels\n",
+    "nz = 600    # number of z slices\n",
+    "ny = 2048   # number of y pixels in each image\n",
+    "nx = 2048   # number of x pixels in each image\n",
+    "save_to = r'D:\\zarr_data\\data.zarr'  # save to this directory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create Zarr folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.isdir(save_to):\n",
+    "    # create new zarr folder\n",
+    "    root = zarr.open(save_to, mode='w')\n",
+    "    ch0 = root.zeros('ch0', shape=(nb_tp, nz, ny, nx), chunks=(1, 64, 512, 512), dtype='i2')\n",
+    "    ch1 = root.zeros('ch1', shape=(nb_ch, nz, ny, nx), chunks=(1, 64, 512, 512), dtype='i2')\n",
+    "    print(root.tree())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open the zarr folder to save data into it\n",
+    "root = zarr.open(save_to, mode='rw')\n",
+    "ch0 = root['ch0']\n",
+    "ch1 = root['ch1']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Readout data from MM and save to zarr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_stack = np.zeros((nz, ny, nx)) # initialize nparray to store a z-stack\n",
+    "for t in range(nb_tp):\n",
+    "    for ch in range(nb_ch):\n",
+    "        for z in range(nb_slices):\n",
+    "            coords_string = \"t={0},p=0,c={1},z={2}\".format(t, ch, z)\n",
+    "            coords = mm.data().create_coords(coords_string)\n",
+    "            mimg = ds.get_image(coords)\n",
+    "            data_stack[z, :, :] = np.reshape(mimg.get_raw_pixels(), \n",
+    "                                             newshape=[mimg.get_height(), \n",
+    "                                                       mimg.get_width()])\n",
+    "        if ch == 0:\n",
+    "            ch0[t, :, :, :] = data_stack\n",
+    "        else:\n",
+    "            ch1[t, :, :, :] = data_stack"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
two jupyter notebooks related with light sheet imaging:
1) convert MM MDA data into zarr. Using pycromanger as a reader to readout large MDA tiff files saved by micro-manager.
2) Stage-scanned light sheet imaging. A new scanning method in light sheet microscopy. 
For details of the method: https://www.biorxiv.org/content/10.1101/2020.09.22.309229v1