### PR TITLE
Allow relative z in multi_d_acquisition_events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Test
+
+# this is heavily based off the jupyterlab-git workflow file created by @fcollonval
+# https://github.com/jupyterlab/jupyterlab-git/blob/a046b66415c6afabcbdf6e624e2a367523ee2e80/.github/workflows/build.yml
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test-3x:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+  
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
+      - name: Install
+        run: |
+          pip install wheel
+          pip install matplotlib==${{ matrix.matplotlib-version}}.*
+          pip install ".[test]"
+      # formatting check for a future PR
+      # - name: Check Formatting
+      #   run: |
+      #     black mpl_interactions --check
+      #     black examples --check
+      - name: Tests
+        run: |
+          pytest --color=yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,16 +39,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
             ${{ runner.os }}-pip-
+
       - name: Install
         run: |
           pip install wheel
-          pip install matplotlib==${{ matrix.matplotlib-version}}.*
           pip install ".[test]"
-      # formatting check for a future PR
-      # - name: Check Formatting
-      #   run: |
-      #     black mpl_interactions --check
-      #     black examples --check
+
       - name: Tests
         run: |
           pytest --color=yes

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ java/src/main/java/pycromanager.iml
 #maven
 java/target
 .idea/
+#jupyter
+.ipynb_checkpoints
+#vim
+*.swp

--- a/docs/source/acq_events.rst
+++ b/docs/source/acq_events.rst
@@ -10,7 +10,7 @@ The :class:`Acquisition<pycromanager.Acquisition>` class enables both simple mut
 Multi-dimensional acquisitions
 ##############################
 
-Multi-dimensional acquisitions are a common type of acquisition in which images are collected across some set of time, z-stack, channel, and xy position. The :meth:`multi_d_acquisition_events<pycromanager.multi_d_acquisition_events>` function can be used to automatically generate the required :ref:`acquisition events<acq_event_spec>`. 
+Multi-dimensional acquisitions are a common type of acquisition in which images are collected across some set of time, z-stack, channel, and xy position. The :meth:`multi_d_acquisition_events<pycromanager.multi_d_acquisition_events>` function can be used to automatically generate the required :ref:`acquisition events<acq_event_spec>`. For a full tutorial on how to use this function see `MDA Tutorial <multi-d-acq-tutorial.ipynb>`_
 
 
 The following shows a the simple example of acquiring a single z-stack:
@@ -104,7 +104,7 @@ A description of all possible fields in an acquisition event can be found in the
 
 
 XY tiling
-===========
+=========
 Pycro-manager has special support for acquisitions in which multiple images are tiled together to form large, high-resolution images. In this mode, data will automatically be saved in a multi-resolution pyramid, so that it can be efficiently viewed at multiple levels of zoom. These features are also available though `Micro-magellan <https://micro-manager.org/wiki/MicroMagellan>`_, which provides a GUI for using them as well as other higher level features.
 
 
@@ -130,7 +130,7 @@ To enable this mode, pass in a value in for the ``tile_overlap`` argument when c
 .. _magellan_acq_launch:
 
 Micro-Magellan Acquisitions
-############################
+###########################
 Another alternative is to launch `Micro-magellan <https://micro-manager.org/wiki/MicroMagellan>`_ acquisitions. These include both regular and `explore acquisitions <https://micro-manager.org/wiki/MicroMagellan#Explore_Acquisitions>`_. In the former case, acquisition events are generated automatically from the Micro-Magellan GUI. In the latter, they are created in response to user clicks.
 
 

--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -11,6 +11,7 @@ Have an application you'd like to contribute to this page? Please `reach out <ht
 	:caption: Contents:
 
 	intermittent_Z_T.ipynb
+	multi-d-acq-tutorial.ipynb
 	TZYX_fast_sequencing_z_indexing.ipynb
 	convert_MM_MDA_data_into_zarr.ipynb
 	pycro_manager_imjoy_tutorial.ipynb
@@ -22,6 +23,9 @@ Have an application you'd like to contribute to this page? Please `reach out <ht
 
 :doc:`intermittent_Z_T`
 	This notebook shows how to repeatedly acquire a short time series and then a z stack at a set with a set delay in between.
+
+:doc:`multi-d-acq-tutorial`
+	This notebook shows how to use the `multi_d_acquisition_events` function to automatically create events to use for acquistion.
 
 :doc:`TZYX_fast_sequencing_z_indexing`
 	This notebook acquires a fast TZYX data series. The camera is run at reduced ROI to achieve higher framerate (here 200 frames per second). Movement of the z stage is "sequenced" to speed up acquisition. The z stage advances to the next position in the sequence when a trigger from the camera is received. This eliminates delays due to software communication.

--- a/docs/source/multi-d-acq-tutorial.ipynb
+++ b/docs/source/multi-d-acq-tutorial.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# Using multi_d_acquistion_events\n",
     "\n",
-    "`multi_d_acquisition_events` is a powerful tool that allows you to specify the acquisition events in a similar manner to using the μmanager gui."
+    "`multi_d_acquisition_events` is a powerful tool that allows you to specify the acquisition events in a similar manner to using the μmanager gui.\n",
+    "\n",
+    "You should also read the [Features page for this function](acq_events.rst#multi-dimensional-acquisitions)."
    ]
   },
   {

--- a/docs/source/multi-d-acq-tutorial.ipynb
+++ b/docs/source/multi-d-acq-tutorial.ipynb
@@ -1,0 +1,433 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using multi_d_acquistion_events\n",
+    "\n",
+    "`multi_d_acquisition_events` is a powerful tool that allows you to specify the acquisition events in a similar manner to using the μmanager gui."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from pycromanager import multi_d_acquisition_events"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specifying xy positions\n",
+    "\n",
+    "To specify the xy positions you need to pass a 2D array with shape (N, 2). However, you may have two separate arrays for `x` and `y`. In the next cells are several different ways to construct an approriate 2D array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0,  0],\n",
+       "       [ 1, -1],\n",
+       "       [ 2, -2],\n",
+       "       [ 3, -3],\n",
+       "       [ 4, -4]])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = np.arange(0, 5)\n",
+    "y = np.arange(0, -5, -1)\n",
+    "\n",
+    "xy = np.hstack([x[:, None], y[:, None]])\n",
+    "xy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'axes': {'position': 0}, 'x': 0, 'y': 0},\n",
+       " {'axes': {'position': 1}, 'x': 1, 'y': -1},\n",
+       " {'axes': {'position': 2}, 'x': 2, 'y': -2},\n",
+       " {'axes': {'position': 3}, 'x': 3, 'y': -3},\n",
+       " {'axes': {'position': 4}, 'x': 4, 'y': -4}]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multi_d_acquisition_events(xy_positions=xy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding z positions\n",
+    "\n",
+    "### Single absolute z position\n",
+    "\n",
+    "To specify a single z value for each position use the `xyz_positions` argument"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'axes': {'position': 0, 'z': 0}, 'x': 0, 'y': 0, 'z': 0},\n",
+       " {'axes': {'position': 1, 'z': 0}, 'x': 1, 'y': -1, 'z': 1},\n",
+       " {'axes': {'position': 2, 'z': 0}, 'x': 2, 'y': -2, 'z': 2},\n",
+       " {'axes': {'position': 3, 'z': 0}, 'x': 3, 'y': -3, 'z': 3},\n",
+       " {'axes': {'position': 4, 'z': 0}, 'x': 4, 'y': -4, 'z': 4}]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "z = np.arange(0, 5)\n",
+    "xyz = np.hstack([x[:, None], y[:, None], z[:, None]])\n",
+    "multi_d_acquisition_events(xyz_positions=xyz)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Relative z positions\n",
+    "\n",
+    "### Relative to each point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'axes': {'position': 0, 'z': 0}, 'x': 0, 'y': 0, 'z': -1},\n",
+       " {'axes': {'position': 0, 'z': 1}, 'x': 0, 'y': 0, 'z': 0},\n",
+       " {'axes': {'position': 0, 'z': 2}, 'x': 0, 'y': 0, 'z': 1},\n",
+       " {'axes': {'position': 1, 'z': 0}, 'x': 1, 'y': -1, 'z': 0},\n",
+       " {'axes': {'position': 1, 'z': 1}, 'x': 1, 'y': -1, 'z': 1},\n",
+       " {'axes': {'position': 1, 'z': 2}, 'x': 1, 'y': -1, 'z': 2},\n",
+       " {'axes': {'position': 2, 'z': 0}, 'x': 2, 'y': -2, 'z': 1},\n",
+       " {'axes': {'position': 2, 'z': 1}, 'x': 2, 'y': -2, 'z': 2},\n",
+       " {'axes': {'position': 2, 'z': 2}, 'x': 2, 'y': -2, 'z': 3},\n",
+       " {'axes': {'position': 3, 'z': 0}, 'x': 3, 'y': -3, 'z': 2},\n",
+       " {'axes': {'position': 3, 'z': 1}, 'x': 3, 'y': -3, 'z': 3},\n",
+       " {'axes': {'position': 3, 'z': 2}, 'x': 3, 'y': -3, 'z': 4},\n",
+       " {'axes': {'position': 4, 'z': 0}, 'x': 4, 'y': -4, 'z': 3},\n",
+       " {'axes': {'position': 4, 'z': 1}, 'x': 4, 'y': -4, 'z': 4},\n",
+       " {'axes': {'position': 4, 'z': 2}, 'x': 4, 'y': -4, 'z': 5}]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multi_d_acquisition_events(xyz_positions=xyz, z_start=-1, z_end=1, z_step=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A range that is shared by all points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'axes': {'position': 0, 'z': 0}, 'x': 0, 'y': 0, 'z': -1},\n",
+       " {'axes': {'position': 0, 'z': 1}, 'x': 0, 'y': 0, 'z': 0},\n",
+       " {'axes': {'position': 0, 'z': 2}, 'x': 0, 'y': 0, 'z': 1},\n",
+       " {'axes': {'position': 1, 'z': 0}, 'x': 1, 'y': -1, 'z': -1},\n",
+       " {'axes': {'position': 1, 'z': 1}, 'x': 1, 'y': -1, 'z': 0},\n",
+       " {'axes': {'position': 1, 'z': 2}, 'x': 1, 'y': -1, 'z': 1},\n",
+       " {'axes': {'position': 2, 'z': 0}, 'x': 2, 'y': -2, 'z': -1},\n",
+       " {'axes': {'position': 2, 'z': 1}, 'x': 2, 'y': -2, 'z': 0},\n",
+       " {'axes': {'position': 2, 'z': 2}, 'x': 2, 'y': -2, 'z': 1},\n",
+       " {'axes': {'position': 3, 'z': 0}, 'x': 3, 'y': -3, 'z': -1},\n",
+       " {'axes': {'position': 3, 'z': 1}, 'x': 3, 'y': -3, 'z': 0},\n",
+       " {'axes': {'position': 3, 'z': 2}, 'x': 3, 'y': -3, 'z': 1},\n",
+       " {'axes': {'position': 4, 'z': 0}, 'x': 4, 'y': -4, 'z': -1},\n",
+       " {'axes': {'position': 4, 'z': 1}, 'x': 4, 'y': -4, 'z': 0},\n",
+       " {'axes': {'position': 4, 'z': 2}, 'x': 4, 'y': -4, 'z': 1}]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multi_d_acquisition_events(xy_positions=xy, z_start=-1, z_end=1, z_step=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time points\n",
+    "\n",
+    "You can specify the number of time points and the delay between them. The `min_start_time` in the events makes it so that there is a garunteed delay between subsequent acquisition events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'axes': {'time': 0}, 'min_start_time': 0},\n",
+       " {'axes': {'time': 1}, 'min_start_time': 10},\n",
+       " {'axes': {'time': 2}, 'min_start_time': 20},\n",
+       " {'axes': {'time': 3}, 'min_start_time': 30},\n",
+       " {'axes': {'time': 4}, 'min_start_time': 40}]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multi_d_acquisition_events(num_time_points=5, time_interval_s=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When combining a time series with a position series we can specify the order using teh `order` argument which has a default order of:\n",
+    "\n",
+    "1. time\n",
+    "2. position\n",
+    "3. channel\n",
+    "4. z"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'axes': {'position': 0, 'time': 0, 'z': 0},\n",
+       "  'x': 0,\n",
+       "  'y': 0,\n",
+       "  'min_start_time': 0,\n",
+       "  'z': -1},\n",
+       " {'axes': {'position': 0, 'time': 0, 'z': 1},\n",
+       "  'x': 0,\n",
+       "  'y': 0,\n",
+       "  'min_start_time': 0,\n",
+       "  'z': 0},\n",
+       " {'axes': {'position': 0, 'time': 1, 'z': 0},\n",
+       "  'x': 0,\n",
+       "  'y': 0,\n",
+       "  'min_start_time': 10,\n",
+       "  'z': -1},\n",
+       " {'axes': {'position': 0, 'time': 1, 'z': 1},\n",
+       "  'x': 0,\n",
+       "  'y': 0,\n",
+       "  'min_start_time': 10,\n",
+       "  'z': 0},\n",
+       " {'axes': {'position': 1, 'time': 0, 'z': 0},\n",
+       "  'x': 1,\n",
+       "  'y': -1,\n",
+       "  'min_start_time': 0,\n",
+       "  'z': -1},\n",
+       " {'axes': {'position': 1, 'time': 0, 'z': 1},\n",
+       "  'x': 1,\n",
+       "  'y': -1,\n",
+       "  'min_start_time': 0,\n",
+       "  'z': 0},\n",
+       " {'axes': {'position': 1, 'time': 1, 'z': 0},\n",
+       "  'x': 1,\n",
+       "  'y': -1,\n",
+       "  'min_start_time': 10,\n",
+       "  'z': -1},\n",
+       " {'axes': {'position': 1, 'time': 1, 'z': 1},\n",
+       "  'x': 1,\n",
+       "  'y': -1,\n",
+       "  'min_start_time': 10,\n",
+       "  'z': 0}]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "xy_small = xy[:2, :]\n",
+    "multi_d_acquisition_events(\n",
+    "    num_time_points=2,\n",
+    "    time_interval_s=10,\n",
+    "    xy_positions=xy_small,\n",
+    "    order=\"ptz\",\n",
+    "    z_start=-1,\n",
+    "    z_end=0,\n",
+    "    z_step=1,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Channels\n",
+    "\n",
+    "The `channel_group`, `channels` and `channel_exposure_ms` arguments can be used to control what channels are collected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'axes': {'position': 0},\n",
+       "  'x': 0,\n",
+       "  'y': 0,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'BF'},\n",
+       "  'exposure': 0},\n",
+       " {'axes': {'position': 0},\n",
+       "  'x': 0,\n",
+       "  'y': 0,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'GFP'},\n",
+       "  'exposure': 1},\n",
+       " {'axes': {'position': 1},\n",
+       "  'x': 1,\n",
+       "  'y': -1,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'BF'},\n",
+       "  'exposure': 0},\n",
+       " {'axes': {'position': 1},\n",
+       "  'x': 1,\n",
+       "  'y': -1,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'GFP'},\n",
+       "  'exposure': 1},\n",
+       " {'axes': {'position': 2},\n",
+       "  'x': 2,\n",
+       "  'y': -2,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'BF'},\n",
+       "  'exposure': 0},\n",
+       " {'axes': {'position': 2},\n",
+       "  'x': 2,\n",
+       "  'y': -2,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'GFP'},\n",
+       "  'exposure': 1},\n",
+       " {'axes': {'position': 3},\n",
+       "  'x': 3,\n",
+       "  'y': -3,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'BF'},\n",
+       "  'exposure': 0},\n",
+       " {'axes': {'position': 3},\n",
+       "  'x': 3,\n",
+       "  'y': -3,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'GFP'},\n",
+       "  'exposure': 1},\n",
+       " {'axes': {'position': 4},\n",
+       "  'x': 4,\n",
+       "  'y': -4,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'BF'},\n",
+       "  'exposure': 0},\n",
+       " {'axes': {'position': 4},\n",
+       "  'x': 4,\n",
+       "  'y': -4,\n",
+       "  'channel': {'group': 'your-channel-group', 'config': 'GFP'},\n",
+       "  'exposure': 1}]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "channel_group = \"your-channel-group\"\n",
+    "channels = [\"BF\", \"GFP\"]\n",
+    "channel_exposures_ms = [15.5, 200]\n",
+    "multi_d_acquisition_events(\n",
+    "    xy_positions=xy,\n",
+    "    channels=channels,\n",
+    "    channel_group=channel_group,\n",
+    "    channel_exposures_ms=channel_exposures_ms,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pycromanager/test/test_MDA_events.py
+++ b/pycromanager/test/test_MDA_events.py
@@ -1,0 +1,244 @@
+from pycromanager import multi_d_acquisition_events
+import numpy as np
+
+x = np.arange(0, 5)
+y = np.arange(0, -5, -1)
+z = np.arange(0, 5)
+
+xy = np.hstack([x[:, None], y[:, None]])
+xyz = np.hstack([x[:, None], y[:, None], z[:, None]])
+
+
+def test_xy_positions():
+    expected = [
+        {"axes": {"position": 0}, "x": 0, "y": 0},
+        {"axes": {"position": 1}, "x": 1, "y": -1},
+        {"axes": {"position": 2}, "x": 2, "y": -2},
+        {"axes": {"position": 3}, "x": 3, "y": -3},
+        {"axes": {"position": 4}, "x": 4, "y": -4},
+    ]
+    events = multi_d_acquisition_events(xy_positions=xy)
+    assert events == expected
+
+
+def test_xyz_positions():
+    expected = [
+        {"axes": {"position": 0, "z": 0}, "x": 0, "y": 0, "z": 0},
+        {"axes": {"position": 1, "z": 0}, "x": 1, "y": -1, "z": 1},
+        {"axes": {"position": 2, "z": 0}, "x": 2, "y": -2, "z": 2},
+        {"axes": {"position": 3, "z": 0}, "x": 3, "y": -3, "z": 3},
+        {"axes": {"position": 4, "z": 0}, "x": 4, "y": -4, "z": 4},
+    ]
+    assert expected == multi_d_acquisition_events(xyz_positions=xyz)
+
+
+def test_xyz_relative_z():
+    expected = [
+        {"axes": {"position": 0, "z": 0}, "x": 0, "y": 0, "z": -1},
+        {"axes": {"position": 0, "z": 1}, "x": 0, "y": 0, "z": 0},
+        {"axes": {"position": 0, "z": 2}, "x": 0, "y": 0, "z": 1},
+        {"axes": {"position": 1, "z": 0}, "x": 1, "y": -1, "z": 0},
+        {"axes": {"position": 1, "z": 1}, "x": 1, "y": -1, "z": 1},
+        {"axes": {"position": 1, "z": 2}, "x": 1, "y": -1, "z": 2},
+        {"axes": {"position": 2, "z": 0}, "x": 2, "y": -2, "z": 1},
+        {"axes": {"position": 2, "z": 1}, "x": 2, "y": -2, "z": 2},
+        {"axes": {"position": 2, "z": 2}, "x": 2, "y": -2, "z": 3},
+        {"axes": {"position": 3, "z": 0}, "x": 3, "y": -3, "z": 2},
+        {"axes": {"position": 3, "z": 1}, "x": 3, "y": -3, "z": 3},
+        {"axes": {"position": 3, "z": 2}, "x": 3, "y": -3, "z": 4},
+        {"axes": {"position": 4, "z": 0}, "x": 4, "y": -4, "z": 3},
+        {"axes": {"position": 4, "z": 1}, "x": 4, "y": -4, "z": 4},
+        {"axes": {"position": 4, "z": 2}, "x": 4, "y": -4, "z": 5},
+    ]
+    assert expected == multi_d_acquisition_events(
+        xyz_positions=xyz, z_start=-1, z_end=1, z_step=1
+    )
+
+
+def test_xy_absolute_z():
+    expected = [
+        {"axes": {"position": 0, "z": 0}, "x": 0, "y": 0, "z": -1},
+        {"axes": {"position": 0, "z": 1}, "x": 0, "y": 0, "z": 0},
+        {"axes": {"position": 0, "z": 2}, "x": 0, "y": 0, "z": 1},
+        {"axes": {"position": 1, "z": 0}, "x": 1, "y": -1, "z": -1},
+        {"axes": {"position": 1, "z": 1}, "x": 1, "y": -1, "z": 0},
+        {"axes": {"position": 1, "z": 2}, "x": 1, "y": -1, "z": 1},
+        {"axes": {"position": 2, "z": 0}, "x": 2, "y": -2, "z": -1},
+        {"axes": {"position": 2, "z": 1}, "x": 2, "y": -2, "z": 0},
+        {"axes": {"position": 2, "z": 2}, "x": 2, "y": -2, "z": 1},
+        {"axes": {"position": 3, "z": 0}, "x": 3, "y": -3, "z": -1},
+        {"axes": {"position": 3, "z": 1}, "x": 3, "y": -3, "z": 0},
+        {"axes": {"position": 3, "z": 2}, "x": 3, "y": -3, "z": 1},
+        {"axes": {"position": 4, "z": 0}, "x": 4, "y": -4, "z": -1},
+        {"axes": {"position": 4, "z": 1}, "x": 4, "y": -4, "z": 0},
+        {"axes": {"position": 4, "z": 2}, "x": 4, "y": -4, "z": 1},
+    ]
+    assert expected == multi_d_acquisition_events(
+        xy_positions=xy, z_start=-1, z_end=1, z_step=1
+    )
+
+
+def test_time_points():
+    expected = [
+        {"axes": {"time": 0}, "min_start_time": 0},
+        {"axes": {"time": 1}, "min_start_time": 10},
+        {"axes": {"time": 2}, "min_start_time": 20},
+        {"axes": {"time": 3}, "min_start_time": 30},
+        {"axes": {"time": 4}, "min_start_time": 40},
+    ]
+    assert expected == multi_d_acquisition_events(num_time_points=5, time_interval_s=10)
+
+
+def test_order():
+    expected = [
+        {
+            "axes": {"position": 0, "time": 0, "z": 0},
+            "x": 0,
+            "y": 0,
+            "min_start_time": 0,
+            "z": -1,
+        },
+        {
+            "axes": {"position": 0, "time": 0, "z": 1},
+            "x": 0,
+            "y": 0,
+            "min_start_time": 0,
+            "z": 0,
+        },
+        {
+            "axes": {"position": 0, "time": 1, "z": 0},
+            "x": 0,
+            "y": 0,
+            "min_start_time": 10,
+            "z": -1,
+        },
+        {
+            "axes": {"position": 0, "time": 1, "z": 1},
+            "x": 0,
+            "y": 0,
+            "min_start_time": 10,
+            "z": 0,
+        },
+        {
+            "axes": {"position": 1, "time": 0, "z": 0},
+            "x": 1,
+            "y": -1,
+            "min_start_time": 0,
+            "z": -1,
+        },
+        {
+            "axes": {"position": 1, "time": 0, "z": 1},
+            "x": 1,
+            "y": -1,
+            "min_start_time": 0,
+            "z": 0,
+        },
+        {
+            "axes": {"position": 1, "time": 1, "z": 0},
+            "x": 1,
+            "y": -1,
+            "min_start_time": 10,
+            "z": -1,
+        },
+        {
+            "axes": {"position": 1, "time": 1, "z": 1},
+            "x": 1,
+            "y": -1,
+            "min_start_time": 10,
+            "z": 0,
+        },
+    ]
+    xy_small = xy[:2, :]
+    assert expected == multi_d_acquisition_events(
+        num_time_points=2,
+        time_interval_s=10,
+        xy_positions=xy_small,
+        order="ptz",
+        z_start=-1,
+        z_end=0,
+        z_step=1,
+    )
+
+
+def test_channels():
+    expected = [
+        {
+            "axes": {"position": 0},
+            "x": 0,
+            "y": 0,
+            "channel": {"group": "your-channel-group", "config": "BF"},
+            "exposure": 0,
+        },
+        {
+            "axes": {"position": 0},
+            "x": 0,
+            "y": 0,
+            "channel": {"group": "your-channel-group", "config": "GFP"},
+            "exposure": 1,
+        },
+        {
+            "axes": {"position": 1},
+            "x": 1,
+            "y": -1,
+            "channel": {"group": "your-channel-group", "config": "BF"},
+            "exposure": 0,
+        },
+        {
+            "axes": {"position": 1},
+            "x": 1,
+            "y": -1,
+            "channel": {"group": "your-channel-group", "config": "GFP"},
+            "exposure": 1,
+        },
+        {
+            "axes": {"position": 2},
+            "x": 2,
+            "y": -2,
+            "channel": {"group": "your-channel-group", "config": "BF"},
+            "exposure": 0,
+        },
+        {
+            "axes": {"position": 2},
+            "x": 2,
+            "y": -2,
+            "channel": {"group": "your-channel-group", "config": "GFP"},
+            "exposure": 1,
+        },
+        {
+            "axes": {"position": 3},
+            "x": 3,
+            "y": -3,
+            "channel": {"group": "your-channel-group", "config": "BF"},
+            "exposure": 0,
+        },
+        {
+            "axes": {"position": 3},
+            "x": 3,
+            "y": -3,
+            "channel": {"group": "your-channel-group", "config": "GFP"},
+            "exposure": 1,
+        },
+        {
+            "axes": {"position": 4},
+            "x": 4,
+            "y": -4,
+            "channel": {"group": "your-channel-group", "config": "BF"},
+            "exposure": 0,
+        },
+        {
+            "axes": {"position": 4},
+            "x": 4,
+            "y": -4,
+            "channel": {"group": "your-channel-group", "config": "GFP"},
+            "exposure": 1,
+        },
+    ]
+    channel_group = "your-channel-group"
+    channels = ["BF", "GFP"]
+    channel_exposures_ms = [15.5, 200]
+    assert expected == multi_d_acquisition_events(
+        xy_positions=xy,
+        channels=channels,
+        channel_group=channel_group,
+        channel_exposures_ms=channel_exposures_ms,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+testpaths = [
+    "pycromanager/test",
+]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=['numpy', 'dask[array]>=2.4.0', 'zmq'],
     python_requires='>=3.6',
-    extra_requires=["pytest"],
+    extras_require={
+        "test": [
+            "pytest"
+        ]
+    },
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=['numpy', 'dask[array]>=2.4.0', 'zmq'],
     python_requires='>=3.6',
-   
+    extra_requires=["pytest"],
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Closes: https://github.com/micro-manager/pycro-manager/issues/153

This should maintain all the previous behaviors but also allow for specifying z positions in these new ways:

- z_positions as 2D array
- z_positions as 1D array
- z_positions as 1D array + relative positions

which is hopefully made clear in the new docs page I added for this. 


Stuff like this is a great candidate for pytest, I thought about adding that but didn't becuase you already have a large user automated testing DIR that I wasn't sure would work with pytest on CI. Let me know what would be best