### PR TITLE
add github action to publish to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+# heavily based on https://github.com/jupyterlab/jupyterlab-git/blob/v0.22.2/.github/workflows/publish.yml
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install packaging setuptools twine wheel
+    - name: Publish the Python package
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
As the title says. This lets you create a git tag, build the wheel, and upload it to pypi in a few clicks via the github interface which I find to be convenient. 

This would require you to create a pypi api token:
![image](https://user-images.githubusercontent.com/10111092/97131681-28bd9100-171b-11eb-8ef9-f44955326dfe.png)
then you would go to the github releases zone:
![image](https://user-images.githubusercontent.com/10111092/97131718-4ab71380-171b-11eb-89f3-ea0b73088db5.png)
draft a new release:
![image](https://user-images.githubusercontent.com/10111092/97131743-57d40280-171b-11eb-9539-09f32e3706a0.png)
then add whatever text you want and it will run the github action in this PR that builds the wheel and pushes it to pypi.


(this was totally unsolicited so no hard feelings if you close this)