### PR TITLE
auto publish on push to _version.py

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,11 @@
-# heavily based on https://github.com/jupyterlab/jupyterlab-git/blob/v0.22.2/.github/workflows/publish.yml
 name: Publish Package
 
 on:
-  release:
-    types: [published]
-
+  push:
+    branches:
+      - master
+    paths: 
+      - 'pycromanager/_version.py'
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -13,7 +14,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -25,3 +26,8 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
+    - name: Create git tag
+      run: |
+        version=$(python -c "from pycromanager import __version__; print(__version__)")
+        git tag $version
+        git push --tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,4 +30,4 @@ jobs:
       run: |
         version=$(python -c "from pycromanager import __version__; print(__version__)")
         git tag $version
-        git push --tag
+        git push origin $version


### PR DESCRIPTION
follow up to https://github.com/micro-manager/pycro-manager/pull/170

On a push to `_version.py` on the master branch the action will trigger and do two things:
1. publish to pypi
2. push a tag to the repo