### PR TITLE
don't require full install dependncies for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,6 @@ jobs:
         twine upload dist/*
     - name: Create git tag
       run: |
-        version=$(python -c "from pycromanager import __version__; print(__version__)")
+        version=$(python -c "from pycromanager._version import __version__; print(__version__)")
         git tag $version
         git push origin $version


### PR DESCRIPTION
so the action doesn't need to have numpy + dask etc... installed to extract the version for the git tag