### PR TITLE
Napari frontend for pycromanager

### DIFF
--- a/java/src/main/java/org/micromanager/remote/RemoteEventSource.java
+++ b/java/src/main/java/org/micromanager/remote/RemoteEventSource.java
@@ -54,7 +54,7 @@ public class RemoteEventSource {
                List<AcquisitionEvent> eList = pullSocket_.next();
                boolean finished = eList.get(eList.size() - 1).isAcquisitionFinishedEvent();
                Future result = acq_.submitEventIterator(eList.iterator());
-//               result.get(); //propogate any exceptions
+               result.get(); //propogate any exceptions
                if (finished || executor_.isShutdown()) {
                   executor_.shutdown();
                   pullSocket_.close();

--- a/java/src/main/java/org/micromanager/remote/RemoteEventSource.java
+++ b/java/src/main/java/org/micromanager/remote/RemoteEventSource.java
@@ -54,14 +54,14 @@ public class RemoteEventSource {
                List<AcquisitionEvent> eList = pullSocket_.next();
                boolean finished = eList.get(eList.size() - 1).isAcquisitionFinishedEvent();
                Future result = acq_.submitEventIterator(eList.iterator());
-               result.get(); //propogate any exceptions
+//               result.get(); //propogate any exceptions
                if (finished || executor_.isShutdown()) {
                   executor_.shutdown();
                   pullSocket_.close();
                   return;
                }
-            } catch (ExecutionException ex) {
-               JOptionPane.showMessageDialog(null, ex.getMessage());
+//            } catch (ExecutionException ex) {
+//               JOptionPane.showMessageDialog(null, ex.getMessage());
             } catch (Exception e) {
                if (executor_.isShutdown()) {
                   return; //It was aborted

--- a/pycromanager/_version.py
+++ b/pycromanager/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 16, 1)
+version_info = (0, 16, 2)
 __version__ = ".".join(map(str, version_info))

--- a/pycromanager/_version.py
+++ b/pycromanager/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 16, 2)
+version_info = (0, 16, 3)
 __version__ = ".".join(map(str, version_info))

--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -5,6 +5,7 @@ from pycromanager.zmq import Bridge
 import copy
 import types
 import numpy as np
+import os
 
 
 def start_headless(
@@ -48,6 +49,8 @@ def start_headless(
             java_loc = "java"
     # This starts Java process and instantiates essential objects (core,
     # acquisition engine, ZMQServer)
+    if not os.path.isfile(java_loc):
+        raise Exception(java_loc + ' does not exist')
     p = subprocess.Popen(
         [
             java_loc,

--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -250,3 +250,6 @@ def multi_d_acquisition_events(
 
     appender(generate_events(base_event, order))
     return events
+
+
+

--- a/pycromanager/napari_util.py
+++ b/pycromanager/napari_util.py
@@ -1,0 +1,59 @@
+from napari.qt import thread_worker
+import numpy as np
+import time
+
+
+
+def get_napari_signaller(viewer):
+
+    def image_saved_callback(axes, d):
+        """
+        Callback function that will be used to signal to napari that a new image is ready
+        """
+        image_saved_callback.dataset = d
+        d.update_ready = True
+
+    def get_dataset_fn():
+        if hasattr(image_saved_callback, 'dataset'):
+            return image_saved_callback.dataset
+        return None
+
+    def update_layer(image):
+        """
+        update the napari layer with the new image
+        """
+        if len(viewer.layers) == 0:
+            viewer.add_image(image)
+        elif image is None:
+            viewer.layers[0].refresh()
+        else:
+            viewer.layers[0].data = image
+
+
+    @thread_worker(connect={'yielded': update_layer})
+    def napari_signaller():
+        """
+        Monitor for signals that Acqusition has a new image ready, and when that happens
+        update napari appropriately
+        """
+        while True:
+            dataset = get_dataset_fn()
+            if dataset is not None and hasattr(dataset, 'update_ready') and dataset.update_ready:
+                dataset.update_ready = False
+                # A new image has arrived, but we only need to regenerate the dask array
+                # if its shape has changed
+                shape = np.array([len(dataset.axes[name]) for name in dataset.axes.keys()])
+                if not hasattr(napari_signaller, 'old_shape') or \
+                        napari_signaller.old_shape.size != shape.size or \
+                        np.any(napari_signaller.old_shape != shape):
+                    image = np.array(dataset.as_array())
+                    napari_signaller.old_shape = shape
+                    yield image
+                else:
+                    # Tell viewer to update but not change data
+                    yield None
+            else:
+                time.sleep(1 / 60) # 60 hz refresh
+
+
+    return napari_signaller, image_saved_callback

--- a/pycromanager/zmq.py
+++ b/pycromanager/zmq.py
@@ -632,10 +632,19 @@ class JavaObjectShadow:
             else:
                 raise Exception("Unrecognized return class")
         elif json_return["type"] == "unserialized-object":
+            def java_iter(a):
+                it = a.iterator()
+                while it.has_next():
+                    yield it.next()
+
             # inherit socket from parent object
-            return self._bridge.get_class(json_return)(
+            obj = self._bridge.get_class(json_return)(
                 socket=self._socket, serialized_object=json_return, bridge=self._bridge
             )
+            if hasattr(obj, 'iterator'):
+                return list(java_iter(obj))
+            else:
+                return obj
         else:
             return deserialize_array(json_return)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-dask[array]
+dask[array]>=2022.2.1
 zmq
 Sphinx==2.1.0
 nbsphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-dask[array]>=2022.2.1
+dask[array]==2022.2.1
 zmq
 Sphinx==2.1.0
 nbsphinx

--- a/test/napari_frontend.py
+++ b/test/napari_frontend.py
@@ -1,3 +1,7 @@
+"""
+Use the Acquisition class with Napari as an image viewer. This is tested in an IDE.
+In other python environments (i.e. notebook), the relevant calls to napari might be different
+"""
 from pycromanager import start_headless
 from pycromanager import Acquisition, multi_d_acquisition_events
 from napari.qt.threading import thread_worker

--- a/test/napari_simple.py
+++ b/test/napari_simple.py
@@ -1,0 +1,18 @@
+from pycromanager import Acquisition, multi_d_acquisition_events, start_headless
+import napari
+
+# Optional: Launch headless mode, which means Micro-Manager does
+# not already need to be open
+# mm_app_path = 'C:/Program Files/Micro-Manager-2.0gamma'
+# config_file = mm_app_path + "/MMConfig_demo.cfg"
+# start_headless(mm_app_path, config_file)
+
+
+acq = Acquisition(directory=r"C:\Users\henry\Desktop\data", name="tcz_acq",
+                  show_display='napari')
+events = multi_d_acquisition_events(num_time_points=8, time_interval_s=2,
+                                 z_start=0, z_end=6, z_step=0.7,)
+acq.acquire(events)
+acq.mark_finished()
+
+napari.run()


### PR DESCRIPTION
This PR enables the use of napari as a frontend for pycro-manager acquisitions, either with the MM GUI running side by side, or independently from python using headless mode

FYI in case this is useful to you @dpshepherd @ptbrown1729 @AlexCoul

Example:
```python
from pycromanager import Acquisition, multi_d_acquisition_events, start_headless
import napari

# Optional: Launch headless mode, which means Micro-Manager does
# not already need to be open
# mm_app_path = 'C:/Program Files/Micro-Manager-2.0gamma'
# config_file = mm_app_path + "/MMConfig_demo.cfg"
# start_headless(mm_app_path, config_file)


acq = Acquisition(directory=r"C:\Users\henry\Desktop\data", name="test_acq",
                  show_display='napari')
events = multi_d_acquisition_events(num_time_points=8, time_interval_s=2,
                                 z_start=0, z_end=6, z_step=0.7,)
acq.acquire(events)
acq.mark_finished()

napari.run()
```