### PR TITLE
Use port argument from start_headless when initializing the Core obje…

### DIFF
--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -81,7 +81,7 @@ def start_headless(
     )
 
     # Initialize core
-    core = Core(timeout=timeout, **core_kwargs)
+    core = Core(timeout=timeout, port=port, **core_kwargs)
 
     core.wait_for_system()
     if config_file is not None:


### PR DESCRIPTION
…ct for this instance.