### PR TITLE
Fix core

### DIFF
--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -81,7 +81,7 @@ def start_headless(
     )
 
     # Initialize core
-    core = Core(timeout=timeout, **core_kwargs)
+    core = Core(timeout=timeout, port=port, **core_kwargs)
 
     core.wait_for_system()
     if config_file is not None:

--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -24,7 +24,7 @@ def start_headless(
 ):
     """
     Start a Java process that contains the neccessary libraries for pycro-manager to run,
-    so that it can be run independently of the Micro-Manager GUI/application. This call
+    so that it can be run independently of the Micro-Manager GUI/application. This calls
     will create and initialize MMCore with the configuration file provided.
 
     On windows plaforms, the Java Runtime Environment will be grabbed automatically

--- a/pycromanager/acquisitions.py
+++ b/pycromanager/acquisitions.py
@@ -379,7 +379,7 @@ class Acquisition(object, metaclass=NumpyDocstringInheritanceMeta):
 
         if kwargs['image_process_fn'] is not None:
             java_processor = JavaObject(
-                "org.micromanager.remote.RemoteImageProcessor"
+                "org.micromanager.remote.RemoteImageProcessor", port=self._bridge_port
             )
             self._remote_acq.add_image_processor(java_processor)
             self._processor_thread = self._start_processor(
@@ -390,14 +390,14 @@ class Acquisition(object, metaclass=NumpyDocstringInheritanceMeta):
         self._hook_threads = []
         if kwargs['event_generation_hook_fn'] is not None:
             hook = JavaObject(
-                "org.micromanager.remote.RemoteAcqHook", args=[self._remote_acq]
+                "org.micromanager.remote.RemoteAcqHook", port=self._bridge_port, args=[self._remote_acq]
             )
             self._hook_threads.append(self._start_hook(hook, kwargs['event_generation_hook_fn'],
                                                        self._event_queue, process=kwargs['process']))
             self._remote_acq.add_hook(hook, self._remote_acq.EVENT_GENERATION_HOOK)
         if kwargs['pre_hardware_hook_fn'] is not None:
             hook = JavaObject(
-                "org.micromanager.remote.RemoteAcqHook", args=[self._remote_acq]
+                "org.micromanager.remote.RemoteAcqHook", port=self._bridge_port, args=[self._remote_acq]
             )
             self._hook_threads.append(self._start_hook(hook,
                                             kwargs['pre_hardware_hook_fn'], self._event_queue,
@@ -405,14 +405,14 @@ class Acquisition(object, metaclass=NumpyDocstringInheritanceMeta):
             self._remote_acq.add_hook(hook, self._remote_acq.BEFORE_HARDWARE_HOOK)
         if kwargs['post_hardware_hook_fn'] is not None:
             hook = JavaObject(
-                "org.micromanager.remote.RemoteAcqHook", args=[self._remote_acq]
+                "org.micromanager.remote.RemoteAcqHook", port=self._bridge_port, args=[self._remote_acq]
             )
             self._hook_threads.append(self._start_hook(hook, kwargs['post_hardware_hook_fn'],
                                                        self._event_queue, process=kwargs['process']))
             self._remote_acq.add_hook(hook, self._remote_acq.AFTER_HARDWARE_HOOK)
         if kwargs['post_camera_hook_fn'] is not None:
             hook = JavaObject(
-                "org.micromanager.remote.RemoteAcqHook", args=[self._remote_acq]
+                "org.micromanager.remote.RemoteAcqHook", port=self._bridge_port, args=[self._remote_acq],
             )
             self._hook_threads.append(self._start_hook(hook, kwargs['post_camera_hook_fn'],
                                                        self._event_queue, process=kwargs['process']))
@@ -424,9 +424,10 @@ class Acquisition(object, metaclass=NumpyDocstringInheritanceMeta):
         self._event_queue = multiprocessing.Queue() if kwargs['process'] else queue.Queue()
 
     def _create_remote_acquisition(self, **kwargs):
-        core = Core()
+        print(f"kwargs {kwargs}")
+        core = Core(port= self._bridge_port, timeout=self._bridge_timeout)
         acq_factory = JavaObject(
-            "org.micromanager.remote.RemoteAcquisitionFactory", args=[core]
+            "org.micromanager.remote.RemoteAcquisitionFactory", port=self._bridge_port, args=[core]
         )
         show_viewer = kwargs['show_display'] == True and (kwargs['directory'] is not None and kwargs['name'] is not None)
 
@@ -655,10 +656,10 @@ class XYTiledAcquisition(Acquisition):
         named_args = {arg_name: l[arg_name] for arg_name in arg_names}
         super().__init__(**named_args)
 
-    def _create_remote_acquisition(self, **kwargs):
-        core = Core()
+    def _create_remote_acquisition(self, port, timeout, **kwargs):
+        core = Core(port=self._bridge_port, timeout=self._bridge_timeout)
         acq_factory = JavaObject(
-            "org.micromanager.remote.RemoteAcquisitionFactory", args=[core]
+            "org.micromanager.remote.RemoteAcquisitionFactory", port=self._bridge_port, args=[core]
         )
 
         show_viewer = kwargs['show_display'] and (kwargs['directory'] is not None and kwargs['name'] is not None)


### PR DESCRIPTION
There were a number of instances where the port number was not being passed through in the creation of Core objects and JavaObjects.  This would cause problems when start_headless was used with a non-default port argument.  This PR hopefully addresses all of the instances where this was the case.