### PR TITLE
Added code to start_headless to skip over initial status messages from micromanager driver.

### DIFF
--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -79,8 +79,13 @@ def start_headless(
         )
     SUBPROCESSES.append(process)
 
-    output = process.stdout.readline()
-    if "STARTED" not in output.decode('utf-8'):
+    started = False
+    output = True
+    # Some drivers output various status messages which need to be skipped over to look for the STARTED token.
+    while output and not started:
+        output = process.stdout.readline()
+        started = "STARTED" in output.decode('utf-8')
+    if not started:
         raise Exception('Error starting headless mode')
     if debug:
         print('Headless mode started')


### PR DESCRIPTION
micromanager driver that may appear before the STARTED token that indicates micromanager startup.