### PR TITLE
fix mda num_time_points=1 bug

### DIFF
--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -193,7 +193,7 @@ def multi_d_acquisition_events(
         if len(order) == 0:
             yield event
             return
-        elif order[0] == "t" and num_time_points is not None:
+        elif order[0] == "t" and num_time_points is not None and num_time_points > 0:
             time_indices = np.arange(num_time_points)
             for time_index in time_indices:
                 new_event = copy.deepcopy(event)

--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -91,7 +91,7 @@ def start_headless(
 
 
 def multi_d_acquisition_events(
-    num_time_points: int=1,
+    num_time_points: int=None,
     time_interval_s: float=0,
     z_start: float=None,
     z_end: float=None,
@@ -111,7 +111,7 @@ def multi_d_acquisition_events(
     Parameters
     ----------
     num_time_points : int
-        How many time points if it is a timelapse (Default value = 1)
+        How many time points if it is a timelapse (Default value = None)
     time_interval_s : float
         the minimum interval between consecutive time points in seconds. Keep at 0 to go as
         fast as possible (Default value = 0)
@@ -193,7 +193,7 @@ def multi_d_acquisition_events(
         if len(order) == 0:
             yield event
             return
-        elif order[0] == "t" and num_time_points != 1:
+        elif order[0] == "t" and num_time_points is not None:
             time_indices = np.arange(num_time_points)
             for time_index in time_indices:
                 new_event = copy.deepcopy(event)


### PR DESCRIPTION
This PR fixes #464 

The behavior in this PR is:

```
multi_d_acquisition_events()
Out[3]: [{'axes': {}}]
multi_d_acquisition_events(num_time_points=1)
Out[4]: [{'axes': {'time': 0}}]
multi_d_acquisition_events(num_time_points=0)
Out[5]: [{'axes': {}}]
multi_d_acquisition_events(num_time_points=3)
Out[6]: [{'axes': {'time': 0}}, {'axes': {'time': 1}}, {'axes': {'time': 2}}]
multi_d_acquisition_events(z_start=0, z_end=3, z_step=1)
Out[7]: 
[{'axes': {'z': 0}, 'z': 0},
 {'axes': {'z': 1}, 'z': 1},
 {'axes': {'z': 2}, 'z': 2},
 {'axes': {'z': 3}, 'z': 3}]
```