### PR TITLE
`np.bool` is deprecated in `numpy` 1.24.0

### DIFF
--- a/pycromanager/zmq_bridge/_bridge.py
+++ b/pycromanager/zmq_bridge/_bridge.py
@@ -865,7 +865,7 @@ _CLASS_NAME_MAPPING = {
 }
 #Used for deserializing java arrarys into numpy arrays
 _JAVA_ARRAY_TYPE_NUMPY_DTYPE = {
-    "boolean[]": np.bool,
+    "boolean[]": np.bool_,
     "byte[]": np.uint8,
     "short[]": np.int16,
     "char[]": np.uint16,


### PR DESCRIPTION
Yesterday's [`numpy`'s 1.24.0 release](https://numpy.org/devdocs/release/1.24.0-notes.html#np-str0-and-similar-are-now-deprecated) deprecates `np.bool` which leads to the following error on a fresh installation:

```
>>> import pycromanager
/Users/talon.chandler/pycro-manager/pycromanager/zmq_bridge/_bridge.py:868: FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.  (This may have returned Python scalars in past versions.
  "boolean[]": np.bool,
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/talon.chandler/pycro-manager/pycromanager/__init__.py", line 3, in <module>
    from pycromanager.acquisitions import Acquisition, MagellanAcquisition, XYTiledAcquisition
  File "/Users/talon.chandler/pycro-manager/pycromanager/acquisitions.py", line 9, in <module>
    from pycromanager.zmq_bridge._bridge import deserialize_array
  File "/Users/talon.chandler/pycro-manager/pycromanager/zmq_bridge/_bridge.py", line 868, in <module>
    "boolean[]": np.bool,
  File "/opt/anaconda3/envs/pycromanager/lib/python3.10/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool'. Did you mean: 'bool_'?
```
This seems to be the only instance of `np.bool` in `pycromanager`. I've tested `import pycromanager`, but I haven't tested any further. 