### PR TITLE
Feature event validation

### DIFF
--- a/pycromanager/_version.py
+++ b/pycromanager/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 24, 0)
+version_info = (0, 24, 1)
 __version__ = ".".join(map(str, version_info))

--- a/pycromanager/acquisitions.py
+++ b/pycromanager/acquisitions.py
@@ -754,14 +754,16 @@ class MagellanAcquisition(Acquisition):
 
 def _validate_acq_events(events: dict or list):
     """
+    Validate if supplied events are a dictionary or a list of dictionaries
 
     Parameters
     ----------
-    events: dict or list
-        Validate if supplied event is a dictionary or a list of dictionaries
+    events : dict or list
 
     Returns
     -------
+    bool
+        True if events are valid, False otherwise
 
     """
     if isinstance(events, dict):
@@ -778,6 +780,19 @@ def _validate_acq_events(events: dict or list):
         return False
 
 def _validate_acq_dict(event: dict):
+    """
+    Validate event dictionary
+
+    Parameters
+    ----------
+    event : dict
+
+    Returns
+    -------
+    bool
+        True if event dict is valid, False otherwise
+
+    """
     if 'axes' in event.keys():
         return True
     else:

--- a/pycromanager/acquisitions.py
+++ b/pycromanager/acquisitions.py
@@ -411,7 +411,11 @@ class Acquisition(object, metaclass=NumpyDocstringInheritanceMeta):
             # manual shutdown
             self._event_queue.put(None)
             return
-        self._event_queue.put(event_or_events)
+
+        if _validate_acq_events(event_or_events):
+            self._event_queue.put(event_or_events)
+        else:
+            raise Exception('Supplied acquisition events are not valid.')
 
     def abort(self, exception=None):
         """
@@ -748,3 +752,33 @@ class MagellanAcquisition(Acquisition):
             self._remote_acq = magellan_api.create_explore_acquisition(False).get_acquisition()
             self._event_queue = None
 
+def _validate_acq_events(events: dict or list):
+    """
+
+    Parameters
+    ----------
+    events: dict or list
+        Validate if supplied event is a dictionary or a list of dictionaries
+
+    Returns
+    -------
+
+    """
+    if isinstance(events, dict):
+        return _validate_acq_dict(events)
+    elif isinstance(events, list):
+        valid_events = []
+        for event in events:
+            if isinstance(event, dict):
+                valid_events.append(_validate_acq_dict(event))
+            else:
+                return False
+        return len(valid_events) > 0 and all(valid_events)
+    else:
+        return False
+
+def _validate_acq_dict(event: dict):
+    if 'axes' in event.keys():
+        return True
+    else:
+        return False

--- a/pycromanager/test/test_acquisition.py
+++ b/pycromanager/test/test_acquisition.py
@@ -43,38 +43,39 @@ def test_timelapse_seq_acq(launch_mm_headless, setup_data_folder):
     dataset.close()
 
 
-# TODO: unskip when ready
-@pytest.mark.skip(reason="Implement event checks in acquisition.py")
 def test_empty_list_acq(launch_mm_headless, setup_data_folder):
     events = []
 
-    with Acquisition(setup_data_folder, 'acq', show_display=False) as acq:
-        acq.acquire(events)
-
-    dataset = acq.get_dataset()
-    assert dataset is None
+    with pytest.raises(Exception):
+        with Acquisition(setup_data_folder, 'acq', show_display=False) as acq:
+            acq.acquire(events)
 
 
-# TODO: unskip when ready
-@pytest.mark.skip(reason="Implement event checks in acquisition.py")
 def test_empty_dict_acq(launch_mm_headless, setup_data_folder):
     events = {}
 
+    with pytest.raises(Exception):
+        with Acquisition(setup_data_folder, 'acq', show_display=False) as acq:
+            acq.acquire(events)
+
+
+def test_empty_dict_list_acq(launch_mm_headless, setup_data_folder):
+    events = [{}, {}]
+
+    with pytest.raises(Exception):
+        with Acquisition(setup_data_folder, 'acq', show_display=False) as acq:
+            acq.acquire(events)
+
+
+# TODO: what should intended behavior be here?
+def test_empty_mda_acq(launch_mm_headless, setup_data_folder):
+    events = multi_d_acquisition_events()
+
     with Acquisition(setup_data_folder, 'acq', show_display=False) as acq:
         acq.acquire(events)
 
     dataset = acq.get_dataset()
     assert dataset is None
-
-# TODO: what should intended behavior be here?
-# def test_empty_mda_acq(launch_mm_headless, setup_data_folder):
-#     events = multi_d_acquisition_events()
-#
-#     with Acquisition(setup_data_folder, 'acq', show_display=False) as acq:
-#         acq.acquire(events)
-#
-#     dataset = acq.get_dataset()
-#     assert dataset is None
 
 
 def test_single_snap_acq(launch_mm_headless, setup_data_folder):

--- a/pycromanager/test/test_acquisition.py
+++ b/pycromanager/test/test_acquisition.py
@@ -67,7 +67,6 @@ def test_empty_dict_list_acq(launch_mm_headless, setup_data_folder):
             acq.acquire(events)
 
 
-# TODO: what should intended behavior be here?
 def test_empty_mda_acq(launch_mm_headless, setup_data_folder):
     events = multi_d_acquisition_events()
 
@@ -75,7 +74,7 @@ def test_empty_mda_acq(launch_mm_headless, setup_data_folder):
         acq.acquire(events)
 
     dataset = acq.get_dataset()
-    assert dataset is None
+    assert dataset.axes == {}
 
 
 def test_single_snap_acq(launch_mm_headless, setup_data_folder):


### PR DESCRIPTION
This PR add minimal acquisition events validation.

In the current implementation acquisition events need to be a dict or list of dict. Event dictionaries need to contain `axes` key. An exception is raised is supplied events are not valid. Requires ndtiff > 1.8.1

We can expand further from here.