### PR TITLE
fix for z_steps in multi_d_acquisition_events

### DIFF
--- a/pycromanager/acq_util.py
+++ b/pycromanager/acq_util.py
@@ -181,7 +181,14 @@ def multi_d_acquisition_events(
         z_positions = xyz_positions[:, 2][:, None]
 
     if has_zsteps:
-        z_rel = np.arange(z_start, z_end + z_step, z_step)
+        z_step = abs(z_step) 
+        if z_start < z_end: 
+            z_rel = np.arange(z_start, z_end + z_step, z_step) 
+            input(f'{z_rel}')
+        else:   
+            z_rel = np.arange(z_start, z_end , -z_step)
+            input(f'{z_rel}')
+            
         if z_positions is None:
             z_positions = z_rel
             if xy_positions is not None:
@@ -265,4 +272,9 @@ def multi_d_acquisition_events(
     appender(generate_events(base_event, order))
     return events
 
+
+t = multi_d_acquisition_events(z_start = 0,
+                           z_end = 3,
+                           z_step = -1)
+print(t)
 

--- a/pycromanager/test/test_MDA_events.py
+++ b/pycromanager/test/test_MDA_events.py
@@ -84,6 +84,22 @@ def test_time_points():
     ]
     assert expected == multi_d_acquisition_events(num_time_points=5, time_interval_s=10)
 
+def test_negative_z_step_direction():
+    expected = [
+        {"axes": {"z": 0}, "z": 0},
+        {"axes": {"z": 1}, "z": 1},
+        {"axes": {"z": 2}, "z": 2},
+        {"axes": {"z": 3}, "z": 3},
+    ]
+    assert expected == multi_d_acquisition_events(z_start=0, z_end=3, z_step=-1)
+    
+def test_positive_z_step_direction():
+    expected = [
+        {'axes': {'z': 0}, 'z': 0}, 
+        {'axes': {'z': 1}, 'z': -1}, 
+        {'axes': {'z': 2}, 'z': -2}
+    ]
+    assert expected == multi_d_acquisition_events(z_start=0, z_end=-3, z_step=1) 
 
 def test_order():
     expected = [


### PR DESCRIPTION
People were noticing weird behavior when using the multi_d_acquisition_events function where if the end value was less then the start value and the step size was not negative the events would end up being empty. I traced it down to np.arange being picky about whether the step size is negative or not based on the start and end values. I added an if else statement to clear it up.