### PR TITLE
StackResampler: clear queue when initializing projections.   

### DIFF
--- a/java/src/main/java/org/micromanager/lightsheet/StackResampler.java
+++ b/java/src/main/java/org/micromanager/lightsheet/StackResampler.java
@@ -345,6 +345,8 @@ public class StackResampler {
     * projection and recon arrays.
     */
    public void initializeProjections() {
+      // Not quite sure why, but this is needed to be able to re-utilize this Resampler.
+      imageQueue_.clear();
       int reconImageZShape = this.reconImageShape_[0];
       int reconImageYShape = this.reconImageShape_[1];
       int reconImageXShape = this.reconImageShape_[2];


### PR DESCRIPTION
  Otherwise, strange ghost images appear when re-utilizing an instance of  this class.