### PR TITLE
Closing dataset on `__exit__`

### DIFF
--- a/pycromanager/acquisition/acquisition_superclass.py
+++ b/pycromanager/acquisition/acquisition_superclass.py
@@ -271,6 +271,7 @@ class Acquisition(metaclass=Meta):
         self.mark_finished()
         # now wait on it to finish
         self.await_completion()
+        self.get_dataset().close()
 
 
 def _validate_acq_events(events: dict or list):


### PR DESCRIPTION
In relation to what I noticed on #717, I noticed that on the `__exit__` statement did not release datasets created during the acquisition. This allows a better graceful exit - at least in my implementation.