### PR TITLE
Do not set the root logger's level to DEBUG

### DIFF
--- a/pycromanager/logging.py
+++ b/pycromanager/logging.py
@@ -1,6 +1,5 @@
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
 main_logger = _base_logger = logging.getLogger("pycromanager")
 
 def set_logger_instance(logger_name: str) -> None:


### PR DESCRIPTION
As described in #766, we should avoid tampering with the `root` logger object.

Happy to set the `"pycromanager"` logger's level to `DEBUG` by default if that is desired, but that also seems not-very-canonical from an outsider's perspective!