### PR TITLE
Bugfix: stop_headless raises AttributeError #808 

### DIFF
--- a/pycromanager/_version.py
+++ b/pycromanager/_version.py
@@ -1,2 +1,2 @@
-version_info = (1, 0, 1)
+version_info = (1, 0, 2)
 __version__ = ".".join(map(str, version_info))

--- a/pycromanager/acquisition/acq_eng_py/internal/engine.py
+++ b/pycromanager/acquisition/acq_eng_py/internal/engine.py
@@ -37,6 +37,9 @@ class Engine:
 
     @staticmethod
     def get_instance():
+        if not hasattr(Engine, 'singleton'):
+            return None
+
         return Engine.singleton
 
     def finish_acquisition(self, acq):

--- a/pycromanager/headless.py
+++ b/pycromanager/headless.py
@@ -58,5 +58,6 @@ def start_headless(
 
 def stop_headless(debug=False):
     terminate_core_instances(debug=debug)
-    Engine.get_instance().shutdown()
+    if Engine.get_instance():
+        Engine.get_instance().shutdown()
 


### PR DESCRIPTION
**Issue** #808:
For Java backend (`python_backend=False`) the `stop_headless` method raises an `AttributeError`.
Fixed by adding a check if `Engine` singleton has been initialized before trying to stop it.