### PR TITLE
Fix CI device interface version mismatch by requiring Python >= 3.10

### DIFF
--- a/.github/workflows/Java_dependency_update.yml
+++ b/.github/workflows/Java_dependency_update.yml
@@ -20,11 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pycro-Manager dependencies branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: ''
         repository: micro-manager/pycro-manager
-        ref: dependencies
         fetch-depth: 0 # check out all branches so main can be merged
         token: ${{ secrets.GITHUB_TOKEN }}
         ref: dependency-update

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
       id: filter
       with:
@@ -52,7 +52,7 @@ jobs:
 
     steps:
     
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 8
         uses: actions/setup-java@v4
@@ -102,7 +102,7 @@ jobs:
       
       
     - name: Checkout Micro-Manager branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
      # env:
       #  GITHUB_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
       with:
@@ -113,7 +113,7 @@ jobs:
     
     
     - name: Checkout pycro-manager # To get the update_mm_ivy.py script
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       env:
         GITHUB_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
      
@@ -202,7 +202,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
       id: filter
       with:
@@ -226,9 +226,9 @@ jobs:
     
     steps:
    
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -29,7 +29,7 @@ jobs:
           mvn dependency:copy-dependencies --file java/pom.xml
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
       - name: Checkout repo

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
       <dependency>
          <groupId>org.micro-manager.ndtiffstorage</groupId>
          <artifactId>NDTiffStorage</artifactId>
-     <version>2.18.4</version>
+     <version>2.19.2</version>
       </dependency>
   </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.pycro-manager</groupId>
     <artifactId>PycroManagerJava</artifactId>
-     <version>0.46.19</version>
+     <version>0.46.20</version>
     <packaging>jar</packaging>
     <name>Pycro-Manager Java</name>
     <description>The Java components of Pycro-Manager</description>
@@ -55,7 +55,7 @@
       <dependency>
          <groupId>org.micro-manager.acqengj</groupId>
          <artifactId>AcqEngJ</artifactId>
-     <version>0.39.2</version>
+     <version>0.39.4</version>
       </dependency>
       <dependency>
          <groupId>org.micro-manager.ndviewer</groupId>

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     url="https://github.com/micro-manager/pycro-manager",
     packages=setuptools.find_packages(),
     install_requires=requirements,
-    python_requires=">=3.6",
+    python_requires=">=3.10",
     extras_require={
         "dev": [
             "pytest",
@@ -35,11 +35,10 @@ setuptools.setup(
         ]
     },
     classifiers=[
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
The python_backend test failed with "MMCore requires 74; device adapter has 75" because the two MM binaries came from independently-versioned sources:

- MMCore came from pymmcore (pulled in unpinned via mmpycorex). On Python 3.9 pip cannot install any interface-75 pymmcore build (they all require Python >= 3.10 and ship no cp39 wheel), so it fell back to the latest 3.9-compatible build (11.10.0.74.0 = interface 74).
- The DemoCamera device adapter came from the latest nightly MM installer downloaded at test time, currently interface 75.

Bump the CI matrix to Python 3.10 so pip can resolve an interface-75 pymmcore matching the nightly's adapters, and update setup.py python_requires/classifiers to >= 3.10 accordingly (3.9 is EOL).

Also update Pycr-Manager and AcqEngJ versions in pom.xml as previously tried in vain by the AcqEngJ workflow.